### PR TITLE
add testing ObjectCreator in test jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,22 @@
                 <autoReleaseAfterClose>false</autoReleaseAfterClose>
               </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/create/*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
in order to re-use all testing object in `ObjectCreator` it would be great to use this in test scope

currently im duplicating this code to use in my tests...

if this can be added in mvn it would be great
