### PR TITLE
new test for line items, shipping details and partnerId

### DIFF
--- a/src/test/java/com/eway/payment/rapid/sdk/integration/transaction/DirectTransactionTest.java
+++ b/src/test/java/com/eway/payment/rapid/sdk/integration/transaction/DirectTransactionTest.java
@@ -93,6 +93,31 @@ public class DirectTransactionTest extends IntegrationTest {
         Assert.assertTrue(res.getErrors().contains("V6101"));
     }
 
+    @Test
+    public void testParterIdInResponse() {
+        String someParterId = "someId";
+        t.setPartnerID(someParterId);
+        CreateTransactionResponse res = client.create(PaymentMethod.Direct, t);
+        Assert.assertTrue(res.getTransactionStatus().isStatus());
+        Assert.assertEquals(someParterId, res.getTransaction().getPartnerID());
+    }
+
+    @Test
+    public void testShippingDetailsInResponse() {
+        CreateTransactionResponse res = client.create(PaymentMethod.Direct, t);
+        Assert.assertTrue(res.getTransactionStatus().isStatus());
+        Assert.assertNotNull(res.getTransaction().getShippingDetails());
+        Assert.assertEquals(t.getShippingDetails(), res.getTransaction().getShippingDetails());
+    }
+
+    @Test
+    public void testLineItemsInResponse() {
+        CreateTransactionResponse res = client.create(PaymentMethod.Direct, t);
+        Assert.assertTrue(res.getTransactionStatus().isStatus());
+        Assert.assertNotNull(res.getTransaction().getLineItems());
+        Assert.assertEquals(t.getLineItems(), res.getTransaction().getLineItems());
+    }
+
     @After
     public void tearDown() {
 


### PR DESCRIPTION
expecting this tests to pass. seems like the sdk isnt returning full transaction details.

when using query transaction by ID after this the details are missing 2.. making this hard to automate a test with sandbox or to verify that eWay got and accepted all the details I sent to them
